### PR TITLE
Enforce using the correct time zone in node

### DIFF
--- a/slackbot/docker-compose.yml
+++ b/slackbot/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   slackbot:
     container_name: slackbot
     image: registry.gitlab.hpi.de/fachschaftsrat/fsr-bot:main
+    environment:
+      TZ: 'Europe/Berlin'
     env_file:
       - .env
     volumes:


### PR DESCRIPTION
Node seems to ignore the timezone settings in `/etc` and just pay attention to the `TZ` environment variable...