### PR TITLE
Remove wallet backend hostname

### DIFF
--- a/wallet/docker-compose.yml
+++ b/wallet/docker-compose.yml
@@ -19,7 +19,6 @@ services:
 
   backend:
     container_name: wallet-backend
-    hostname: api.wallet.myhpi.de
     build: ./backend
     depends_on:
       - db


### PR DESCRIPTION
When a hostname is set, docker networking automatically tries to route requests from other containers to this hostname trough docker networks. This interferes with our firewall.

Removing the hostname should fix this problem.