### PR TITLE
Update myHPI to v1.0.1

### DIFF
--- a/myhpi/docker-compose.yml
+++ b/myhpi/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
 
   myhpi_django:
-    image: ghcr.io/fsr-de/myhpi:latest
+    image: ghcr.io/fsr-de/myhpi:v1.0.1
     hostname: django.myhpi.local
     restart: unless-stopped
     command: uwsgi /app/uwsgi.ini


### PR DESCRIPTION
Thanks to https://github.com/fsr-de/myHPI/pull/463, we can now use version tags