### PR TITLE
Update Grafana and dependencies

### DIFF
--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
 
   grafana:
-    image: grafana/grafana-oss:11.5.1
+    image: grafana/grafana-oss:12.0.0-security-01
     hostname: grafana.myhpi.local
     restart: unless-stopped
     volumes:
@@ -18,7 +18,7 @@ services:
       - internal
 
   renderer:
-    image: grafana/grafana-image-renderer:3.12.0
+    image: grafana/grafana-image-renderer:3.12.5
     restart: unless-stopped
     environment:
       AUTH_TOKEN: ${RENDERER_TOKEN}
@@ -26,7 +26,7 @@ services:
       - internal
 
   prometheus:
-    image: prom/prometheus:v3.1.0
+    image: prom/prometheus:v3.4.0
     restart: unless-stopped
     command:
       # Keep default flags from Dockerfile
@@ -45,7 +45,7 @@ services:
       - internal
 
   db:
-    image: mariadb:11.6
+    image: mariadb:11.7
     restart: unless-stopped
     command: --transaction-isolation=READ-COMMITTED
     volumes:


### PR DESCRIPTION
- Grafana to 12.0.0
- Grafana Image Renderer to 3.12.5
- Prometheus to 3.4.0
- MariaDB to 11.7